### PR TITLE
Fix README markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Run deep learning inference on your local machine with real-time performance!
 
 ---
 
-From the project root, run below with replace your ip adress
+From the project root, run the command below after replacing your IP address:
 
 ```bash
 uvicorn app.main:app --host 172.19.75.30 --port 8000 --reload
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- correct IP address wording
- close the bash code block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686b2449dfc8833381ab445e233a6554